### PR TITLE
Fix Brazilian Portuguese translation

### DIFF
--- a/sources/language/pt_br.json
+++ b/sources/language/pt_br.json
@@ -3,13 +3,13 @@
         "Olá, eu sou um Bot que envia um captcha de imagem para cada novo usuário que entra no grupo e expulsa aquele que não enviar o captcha no tempo definido.\n\nSe um usuário tentar entrar no grupo 5 vezes sem enviar o captcha corretamente, vou assumir que esse \"usuário\" é um Bot, e ele será banido. Também, qualquer mensagem que contenha um URL que tenha sido enviado por um novo \"usuário\" antes da conclusão do captcha, será considerada Spam e será excluída.\n\nLembre-se de dar privilégios de administrador para que eu possa expulsar-banir usuários e excluir mensagens do grupo.\n\nConfira o comando /help para saber mais sobre como me usar.\n\nEu sou útil? Confira o comando /about e considere fazer uma doação para me manter ativo.",
 
     "HELP" :
-        "Ajuda do Bot:\n————————————————\n- Eu sou um Bot que envia um captcha para cada novo usuário que entra no grupo e expulsa aquele que não enviar o captcha no tempo definido.\n\n- Se um usuário tentar entrar no grupo 5 vezes sem enviar o captcha corretamente, vou assumir que esse “usuário” é um Bot, e ele será banido.\n\n- Qualquer mensagem que contenha um URL que tenha sido enviado por um novo \"usuário\" antes da conclusão do captcha, será considerada Spam e será excluída.\n\n- Você tem que me dar privilégios de administrador para que eu possa expulsar e banir usuários, e remover mensagens.\n\n- Para manter o grupo limpo, eu removo automaticamente todas as mensagens relacionadas a mim quando um captacha não é enviado e o usuário é expulso (depois de 5 minutos).\n\n- O tempo de espera para que o usuário envie o captcha é de 5 minutos, mas ele pode ser configurado usando o comando /time.\n\n- Você pode ativar ou desativar a proteção captcha usando os comandos /enable e /disable.\n\n- Comandos de configuração somente podem ser usados pelos Administradores do grupo.\n\n- Você pode definir o idioma que eu falo usando o comando /language.\n\n- Você pode configurar o grau de dificuldade do captcha usando a opção /difficulty.\n\nVocê pode definir se o captacha terá apenas números (o padrão) ou números e letras, usando a opção /captcha_mode.\n\n- Você pode configurar uma mensagem de boas-vindas personalizada com o comando /welcome_msg.\n\n- Use a opção /commands para ver a lista de todos os comandos com uma breve descrição de cada um deles.",
+        "Ajuda do Bot:\n————————————————\n- Eu sou um Bot que envia um captcha para cada novo usuário que entra no grupo e expulsa aquele que não enviar o captcha no tempo definido.\n\n- Se um usuário tentar entrar no grupo 5 vezes sem enviar o captcha corretamente, vou assumir que esse “usuário” é um Bot, e ele será banido.\n\n- Qualquer mensagem que contenha um URL que tenha sido enviado por um novo \"usuário\" antes da conclusão do captcha, será considerada Spam e será excluída.\n\n- Você tem que me dar privilégios de administrador para que eu possa expulsar e banir usuários, e remover mensagens.\n\n- Para manter o grupo limpo, eu removo automaticamente todas as mensagens relacionadas a mim quando um captcha não é enviado e o usuário é expulso (depois de 5 minutos).\n\n- O tempo de espera para que o usuário envie o captcha é de 5 minutos, mas ele pode ser configurado usando o comando /time.\n\n- Você pode ativar ou desativar a proteção captcha usando os comandos /enable e /disable.\n\n- Comandos de configuração somente podem ser usados pelos Administradores do grupo.\n\n- Você pode definir o idioma que eu falo usando o comando /language.\n\n- Você pode configurar o grau de dificuldade do captcha usando a opção /difficulty.\n\nVocê pode definir se o captcha terá apenas números (o padrão) ou números e letras, usando a opção /captcha_mode.\n\n- Você pode configurar uma mensagem de boas-vindas personalizada com o comando /welcome_msg.\n\n- Use a opção /commands para ver a lista de todos os comandos com uma breve descrição de cada um deles.",
 
     "CMD_NOT_ALLOW" :
         "Apenas um Admin pode usar esse comando",
 
     "LANG_CHANGE" :
-        "Idioma definido para Português (Brasil).",
+        "Idioma definido para português (Brasil).",
 
     "LANG_SAME" :
         "Eu já estou em Português (Brasil).\n\nIdiomas suportados:\n{}",
@@ -39,13 +39,13 @@
         "O nível de dificuldade fornecido não é um número.",
 
     "DIFFICULTY_NOT_ARG" :
-        "O comando exige um nível de deficuldade como argumento (de 1 a 5).\n\nExemplos:\n/difficulty 1\n/difficulty 2\n/difficulty 3\n/difficulty 4\n/difficulty 5",
+        "O comando exige um nível de dificuldade como argumento (de 1 a 5).\n\nExemplos:\n/difficulty 1\n/difficulty 2\n/difficulty 3\n/difficulty 4\n/difficulty 5",
 
     "CAPTCHA_MODE_CHANGE" :
-        "O modo-carater do captcha mudou para \"{}\".",
+        "O modo-caractere do captcha mudou para \"{}\".",
 
     "CAPTCHA_MODE_INVALID" :
-        "Modo-caracter inválido. As opções disponíveis são: \"nums\", \"hex\" ou \"ascii\".\n\nExemplos:\n/captcha_mode nums\n/captcha_mode hex\n/captcha_mode ascii",
+        "Modo-caractere inválido. As opções disponíveis são: \"nums\", \"hex\" ou \"ascii\".\n\nExemplos:\n/captcha_mode nums\n/captcha_mode hex\n/captcha_mode ascii",
 
     "CAPTCHA_MODE_NOT_ARG" :
         "O comando exite um modo definido. As opções disponíveis são:\n- Captchas numéricos (\"nums\").\n- Captchas hexadecimais, com números e letras A-F (\"hex\").\n- Captchas com números e letras A-Z (\"ascii\").\n\nExemplos:\n/captcha_mode nums\n/captcha_mode hex\n/captcha_mode ascii",
@@ -60,7 +60,7 @@
         "Coloque a mensagem de boas-vindas após o comando.\n\nExemplo:\n/welcome_msg Olá $user, seja bem-vindo ao grupo e lembre-se de ser respeitoso com outros usuários.\n\nDesativar a mensagem:\n/welcome_msg disable",
 
     "NEW_USER_CAPTCHA_CAPTION" :
-        "Olá {}, seja bem-vindo ao {}. Por favor envie uma mensagem com o número que aparece neste captcha para que possamos nos certificar que você é humano. Se você não enviar o captcha em {} minutos, você será automaticamente expulso do grupo. se houver letras, maiúsculo e minúsculo faz diferença.",
+        "Olá {}, seja bem-vindo ao {}. Por favor envie uma mensagem com o número que aparece neste captcha para que possamos nos certificar que você é humano. Se você não enviar o captcha em {} minutos, você será automaticamente expulso do grupo. Se houver letras, maiúsculo e minúsculo faz diferença.",
 
     "CAPTCHA_SOLVED" :
         "Captcha enviado, usuário verificado.\nSeja bem-vindo ao grupo {}",
@@ -87,16 +87,16 @@
         "Eu tentei apagar essa mensagem, mas eu não tenho poderes administrativos para remover mensagens que não foram enviadas por mim",
 
     "NEW_USER_BAN" :
-        "Alerta: Esta é a quinta vez que {} tenta entrar no grupo mas falha ao enviar o captcha. O \"usuário\" foi banido. Para deixá-lo entrar de novo, um administrador tem que remover as restrições, manualmente..",
+        "Alerta: Esta é a quinta vez que {} tenta entrar no grupo e falha ao enviar o captcha. O \"usuário\" foi banido. Para deixá-lo entrar de novo, um administrador tem que remover as restrições, manualmente..",
 
     "NEW_USER_BAN_NOT_IN_CHAT" :
-        "Alerta: Esta é a quinta vez que {} tenta entrar no grupo mas falha ao enviar o captcha. Eu tentei banir o \"usuário\", mas ele não está mais no grupo (ele saiu ou foi expulso por um Admin).",
+        "Alerta: Esta é a quinta vez que {} tenta entrar no grupo e falha ao enviar o captcha. Eu tentei banir o \"usuário\", mas ele não está mais no grupo (ele saiu ou foi expulso por um Admin).",
 
     "NEW_USER_BAN_NOT_RIGHTS" :
-        "Alerta: Esta é a quinta vez que {} tenta entrar no grupo mas falha ao enviar o captcha. Eu tentei banir o \"usuário\", mas eu não tenho poderes administrativos para banir usuários do grupo.",
+        "Alerta: Esta é a quinta vez que {} tenta entrar no grupo e falha ao enviar o captcha. Eu tentei banir o \"usuário\", mas eu não tenho poderes administrativos para banir usuários do grupo.",
 
     "BOT_CANT_BAN" :
-        "Alerta: Esta é a quinta vez que {} tenta entrar no grupo mas falha ao enviar o captcha. Eu tentei banir o \"usuário\", mas algo deu errado (talvez algo relacionado à rede ou servidor). Não pude fazê-lo.",
+        "Alerta: Esta é a quinta vez que {} tenta entrar no grupo e falha ao enviar o captcha. Eu tentei banir o \"usuário\", mas algo deu errado (talvez algo relacionado à rede ou servidor). Não pude fazê-lo.",
 
     "SPAM_DETECTED_RM" :
         "Detectou uma mensagem com um URL (ou alias) de {}, que ainda não resolveu o captcha. A mensagem foi removida em prol de um Telegram livre de spam :)",
@@ -132,5 +132,5 @@
         "Este é um Software Livre licenciado pela GNU-GPL Bot desenvolvido pelo {}.\n\nVocê pode acessar o código fonte aqui:\n{}\n\nGosta do meu trabalho? Me pague um café.\n\nPaypal:\n{}\n\nBTC:\n{}",
 
     "COMMANDS" :
-        "Lista de comandos:\n————————————————\n/start - Mostrar informações básicas sobre o bot.\n\n/help - Mostra informações de ajuda.\n\n/commands - Mostra a lista de todos os comandos disponíveis e suas descrições.\n\n/language - Permite definir o idioma das mensagens do bot. Os idiomas disponíveis são: {}.\n\n/time - Permite alterar o tempo disponível para resolver um captcha.\n\n/difficulty - Permite alterar o nível de dificuldade do captcha (de 1 a 5).\n\n/captcha_mode - Permite alterar o modo-carater do captcha (nums: apenas números, hex: números e letras A-F, ascii: números e letras A-Z).\n\n/welcome_msg - Permite configurar uma mensagem de boas-vindas que é enviada após a resolução do captcha.\n\n/enable - Ativa a proteção captcha no grupo.\n\n/disable - Desativa a proteção captcha no grupo.\n\n/version - Mostra a versão do Bot.\n\n/about - Mostra informações \"sobre\"."
+        "Lista de comandos:\n————————————————\n/start - Mostrar informações básicas sobre o bot.\n\n/help - Mostra informações de ajuda.\n\n/commands - Mostra a lista de todos os comandos disponíveis e suas descrições.\n\n/language - Permite definir o idioma das mensagens do bot. Os idiomas disponíveis são: {}.\n\n/time - Permite alterar o tempo disponível para resolver um captcha.\n\n/difficulty - Permite alterar o nível de dificuldade do captcha (de 1 a 5).\n\n/captcha_mode - Permite alterar o modo-caractere do captcha (nums: apenas números, hex: números e letras A-F, ascii: números e letras A-Z).\n\n/welcome_msg - Permite configurar uma mensagem de boas-vindas que é enviada após a resolução do captcha.\n\n/enable - Ativa a proteção captcha no grupo.\n\n/disable - Desativa a proteção captcha no grupo.\n\n/version - Mostra a versão do Bot.\n\n/about - Mostra informações \"sobre\"."
 }


### PR DESCRIPTION
This PR fixes the follow:
- Typo in "captacha", should be "captcha"
- Language name in lowercase (differently from in English, language names in Portuguese do not start with uppercase)
- Typo in "deficuldade", should be "dificuldade"
- Typo in "modo-caracter", where "caracter" should be "caractere"
- "mas" (but in Portuguese) replaced with "e" (and in Portuguese), it looks better in the sentence