### PR TITLE
Ignore list feature

### DIFF
--- a/sources/language/en.json
+++ b/sources/language/en.json
@@ -62,6 +62,33 @@
     "NEW_USER_CAPTCHA_CAPTION" : 
         "Hello {}, welcome to {}, please write a message with the numbers and/or letters that appears in this image to verify that you are a human. If you don't resolve the captcha in {} mins, you will be automatically kicked from the group.",
 
+    "IGNORE_LIST_ADD_NOT_ARG" :
+        "Please, place the user's ID (not username) after the command.\n\nExample:\n/add_ignore 1234567890.",
+
+    "IGNORE_LIST_ADD_LIMIT_EXCEEDED":
+        "Unfortunately, you can't add more than 100 users into the ignore list.",
+
+    "IGNORE_LIST_ADD_INCORRECT_ID":
+        "This ID is incorrect, it has to consist only of numbers.",
+
+    "IGNORE_LIST_ADD_SUCCESS":
+        "This ID has been added successfully!",
+
+    "IGNORE_LIST_NO_PRIVATE_CHATS":
+        "Unfortunately, using this command is forbidden for private chats.",
+
+    "IGNORE_LIST_REMOVE_NOT_ARG" :
+        "Please, place the user's ID (not username) after the command.\n\nExample:\n/remove_ignore 1234567890.",
+
+    "IGNORE_LIST_REMOVE_SUCCESS":
+        "This ID has been removed successfully!",
+
+    "IGNORE_LIST_REMOVE_NOT_IN_LIST":
+        "This ID is not in ignore list, nothing was done.",
+
+    "IGNORE_LIST_EMPTY":
+        "Ignore list of the chat is empty.",
+
     "CAPTCHA_SOLVED" : 
         "Captcha solved, user verified.\nWelcome to the group {}",
 
@@ -132,5 +159,5 @@
         "This Bot is free software and open-sourced under the GNU-GPL license.\nBot Developed by {}.\n\nYou can check the code here:\n{}\n\nDo you like my work? Buy me a coffee.\n\nPaypal:\n{}\n\nBTC:\n{}",
 
     "COMMANDS" : 
-        "List of commands:\n————————————————\n/start - Shows the initial information about the bot.\n\n/help - Shows the help information.\n\n/commands - Shows this message. Information about all the available commands and their description.\n\n/language - Allows to change the language of the bot's messages.\n\n/time - Allows changing the time available to solve a captcha.\n\n/difficulty - Allows changing captcha difficulty level (from 1 to 5).\n\n/captcha_mode - Allows changing captcha character-mode (nums: just numbers, hex: numbers and A-F chars, ascii: numbers and A-Z chars).\n\n/welcome_msg - Allows configure a welcome message that is sent after resolving the captcha.\n\n/enable - Enable the captcha protection of the group.\n\n/disable - Disable the captcha protection of the group.\n\n/version - Show the version of the Bot.\n\n/about - Show about info."
+        "List of commands:\n————————————————\n/start - Shows the initial information about the bot.\n\n/help - Shows the help information.\n\n/commands - Shows this message. Information about all the available commands and their description.\n\n/language - Allows to change the language of the bot's messages.\n\n/time - Allows changing the time available to solve a captcha.\n\n/difficulty - Allows changing captcha difficulty level (from 1 to 5).\n\n/captcha_mode - Allows changing captcha character-mode (nums: just numbers, hex: numbers and A-F chars, ascii: numbers and A-Z chars).\n\n/welcome_msg - Allows configure a welcome message that is sent after resolving the captcha.\n\n/add_ignore - Do not ask an ignored user the captcha.\n\n/remove_ignore - Stop ignoring a user.\n\n/ignore_list - list of ignored users' IDs.\n\n/enable - Enable the captcha protection of the group.\n\n/disable - Disable the captcha protection of the group.\n\n/version - Show the version of the Bot.\n\n/about - Show about info."
 }


### PR DESCRIPTION
In my chat a user likes to join the chat every time he posts something and instantly quit. For that I've added Ignore_List feature.

Now every configs.json includes one new parameter **"Ignore_List"** which is a list of user IDs.

There are 3 new commands: /add_ignore, /remove_ignore and /ignore_list.

When an ignored user enters the chat, the bot ignores the user and prints `User is in ignore list. Skipping the captcha process.` in the console.