### PR TITLE
Dockerfile and Makefile refactor

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ ARG BOT_USER="nobody"
 ARG BOT_GROUP="nogroup"
 ARG BOT_HOME_DIR="/srv"
 ARG REPO_NAME="TLG_JoinCaptchaBot"
-ARG GITHUB_URL="https://github.com/LIDSoL/${REPO_NAME}"
+ARG GITHUB_URL="https://github.com/J-Rios/${REPO_NAME}"
 
 # This represents an invalid token and should always exist in
 # the "stock" constants.py file.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@ ARG BOT_USER="nobody"
 ARG BOT_GROUP="nogroup"
 ARG BOT_HOME_DIR="/srv"
 ARG REPO_NAME="TLG_JoinCaptchaBot"
+ARG APP_DIR="${BOT_HOME_DIR}/app"
 ARG GITHUB_URL="https://github.com/J-Rios/${REPO_NAME}"
 
 # This represents an invalid token and should always exist in
@@ -32,6 +33,7 @@ ENV BOT_PROJECT="${BOT_PROJECT}" \
     BOT_GROUP="${BOT_GROUP}" \
     BOT_HOME_DIR="${BOT_HOME_DIR}" \
     REPO_NAME="${REPO_NAME}" \
+    APP_DIR="${APP_DIR}" \
     GITHUB_URL="${GITHUB_URL}" \
     INVALID_TOKEN="${INVALID_TOKEN}" \
     BOT_TOKEN="${BOT_TOKEN}" \
@@ -71,13 +73,14 @@ FROM builder-deps AS builder
 # Build the code as unprivileged user
 USER ${BOT_USER}
 WORKDIR ${BOT_HOME_DIR}
-RUN git clone --recurse-submodules ${GITHUB_URL} && \
-    pip3 install --user --requirement ${REPO_NAME}/requirements.txt && \
-    cd ${REPO_NAME}/sources && \
+RUN git clone --recurse-submodules ${GITHUB_URL} ${APP_DIR} && \
+    pip3 install --user --requirement ${APP_DIR}/requirements.txt && \
+    cd ${APP_DIR}/sources && \
     sed -i -e "s/${INVALID_TOKEN}/${BOT_TOKEN}/g" constants.py && \
     sed -i -e "s/^\(\s\+\"INIT_LANG\"\)[^:]*:.*/\1 : \"${BOT_LANG}\",/g" constants.py && \
     chown -cR ${BOT_USER}:${BOT_GROUP} ${BOT_HOME_DIR} && \
-    rm -rf ${BOT_HOME_DIR}/.cache ${BOT_HOME_DIR}/${REPO_NAME}/.git
+    rm -rf ${BOT_HOME_DIR}/.cache && \
+    find ${APP_DIR} -iname '.git*' -print0 | xargs -0 -r -t rm -rf
 
 ################################################################################
 
@@ -95,6 +98,6 @@ RUN chown -R "${BOT_USER}:${BOT_GROUP}" ${BOT_HOME_DIR} && \
 
 # Set up to run as an unprivileged user
 USER ${BOT_USER}
-WORKDIR ${BOT_HOME_DIR}/${REPO_NAME}/sources
+WORKDIR ${APP_DIR}/sources
 CMD ["./entrypoint.sh"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,17 @@
-FROM debian:buster
+# This Dockerfile has buildkit syntax, to allow build steps to be cached
+# and speed up when rebuilding
 
-MAINTAINER Marco Paganini <paganini@paganini.net>
+# TODO: Check if we can build this FROM python:3-alpine to slim down the image
 
+FROM python:3-slim-buster AS base
+
+# Build ARGs
 ARG BOT_PROJECT="captcha-bot"
-ARG BOT_USER="captcha-bot"
-ARG BOT_HOME_DIR="/home/${BOT_USER}"
-ARG GITHUB_URL="https://github.com/J-Rios/TLG_JoinCaptchaBot"
-
-# Change this to an user_id that does not own anything on the host.
-ARG UID=62999
+ARG BOT_USER="nobody"
+ARG BOT_GROUP="nogroup"
+ARG BOT_HOME_DIR="/srv"
+ARG REPO_NAME="TLG_JoinCaptchaBot"
+ARG GITHUB_URL="https://github.com/LIDSoL/${REPO_NAME}"
 
 # This represents an invalid token and should always exist in
 # the "stock" constants.py file.
@@ -20,30 +23,78 @@ ARG INVALID_TOKEN="XXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 ARG BOT_TOKEN
 
 # Default language (override when building -- must be all CAPS.)
+# check Makefile for a list of supported languages
 ARG BOT_LANG="EN"
 
-# OS and base environment layer.
-RUN groupadd --gid ${UID} ${BOT_USER} && \
-    useradd --uid ${UID} --gid ${UID} --shell /bin/bash --home-dir ${BOT_HOME_DIR} ${BOT_USER} && \
-    apt-get update && \
-    apt-get install --yes bash coreutils git procps python3 python3-pip && \
-    apt-get install --yes libtiff5-dev libjpeg62-turbo-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python-tk
+# Export ARGs as ENV vars so they can be shared among steps
+ENV BOT_PROJECT="${BOT_PROJECT}" \
+    BOT_USER="${BOT_USER}" \
+    BOT_GROUP="${BOT_GROUP}" \
+    BOT_HOME_DIR="${BOT_HOME_DIR}" \
+    REPO_NAME="${REPO_NAME}" \
+    GITHUB_URL="${GITHUB_URL}" \
+    INVALID_TOKEN="${INVALID_TOKEN}" \
+    BOT_TOKEN="${BOT_TOKEN}" \
+    BOT_LANG="${BOT_LANG}" \
+    DEBIAN_FRONTEND=noninteractive \
+    APT_OPTS="-q=2 --yes"
 
-# TLG captcha bot layer.
-RUN mkdir -p "${BOT_HOME_DIR}" && \
-    cd "${BOT_HOME_DIR}" && \
-    git clone --recurse-submodules "${GITHUB_URL}" && \
-    # In Debian, installing the telegram library in the requirements.txt file
-    # causes imports to fail.
-    pip3 install python_telegram_bot==11.1.0 && \
-    pip3 install Pillow==6.0.0 && \
-    cd TLG_JoinCaptchaBot/sources && \
+# Prepare a directory to run with an unprivileged user
+RUN chown -cR "${BOT_USER}:${BOT_GROUP}" ${BOT_HOME_DIR} && \
+    usermod -d ${BOT_HOME_DIR} ${BOT_USER}
+
+################################################################################
+
+FROM base AS builder-deps
+
+# Install build dependencies
+RUN apt ${APT_OPTS} update && \
+    apt ${APT_OPTS} --no-install-recommends install apt-utils && \
+    apt ${APT_OPTS} --no-install-recommends install \
+      build-essential \
+      git \
+      procps  \
+      libtiff5-dev \
+      libjpeg62-turbo-dev \
+      zlib1g-dev \
+      libfreetype6-dev \
+      liblcms2-dev \
+      libwebp-dev \
+      tcl8.6-dev \
+      tk8.6-dev \
+      python-tk
+
+################################################################################
+
+FROM builder-deps AS builder
+
+# Build the code as unprivileged user
+USER ${BOT_USER}
+WORKDIR ${BOT_HOME_DIR}
+RUN git clone --recurse-submodules ${GITHUB_URL} && \
+    pip3 install --user --requirement ${REPO_NAME}/requirements.txt && \
+    cd ${REPO_NAME}/sources && \
     sed -i -e "s/${INVALID_TOKEN}/${BOT_TOKEN}/g" constants.py && \
     sed -i -e "s/^\(\s\+\"INIT_LANG\"\)[^:]*:.*/\1 : \"${BOT_LANG}\",/g" constants.py && \
-    chown -R "${BOT_USER}":"${BOT_USER}" "${BOT_HOME_DIR}" && \
-    echo "rm -f ./data/captchas/*; python3 -u join_captcha_bot.py" >run_in_docker && \
-    chmod 755 kill run run_in_docker status && \
-    cd ..
+    chown -cR ${BOT_USER}:${BOT_GROUP} ${BOT_HOME_DIR} && \
+    rm -rf ${BOT_HOME_DIR}/.cache ${BOT_HOME_DIR}/${REPO_NAME}/.git
 
+################################################################################
 
-CMD ["/bin/su", "-", "captcha-bot", "-c", "bash -c 'cd /home/captcha-bot/TLG_JoinCaptchaBot/sources && ./run_in_docker'"]
+FROM base AS app
+
+# Address the pip warning regarding PATH
+ENV PATH="${PATH}:${BOT_HOME_DIR}/.local/bin"
+
+# Import built code from previous step
+COPY --from=builder ${BOT_HOME_DIR} ${BOT_HOME_DIR}
+
+# Adjust privileges
+RUN chown -R "${BOT_USER}:${BOT_GROUP}" ${BOT_HOME_DIR} && \
+    usermod -d ${BOT_HOME_DIR} ${BOT_USER}
+
+# Set up to run as an unprivileged user
+USER ${BOT_USER}
+WORKDIR ${BOT_HOME_DIR}/${REPO_NAME}/sources
+CMD ["./entrypoint.sh"]
+

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -24,7 +24,7 @@ ifneq ($(strip $(VALID_LANG)), true)
     $(error Invalid default language provided)
 endif
 
-.PHONY: build force test
+.PHONY: build force test debug
 
 build:
 	docker build -f "${DOCKERFILE}" -t "${NAME_LOW}" --build-arg BOT_TOKEN="${BOT_TOKEN}" --build-arg BOT_LANG="${BOT_LANG_UPP}" .
@@ -35,3 +35,6 @@ force:
 test:
 	$(MAKE) -e BOT_TOKEN=XXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 	docker run -it $(NAME_LOW):latest
+
+debug:	test
+	docker run -it --user=root --entrypoint ${SHELL} $(NAME_LOW):latest

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,8 @@
+SHELL = /bin/bash
 NAME = captcha-bot
 BOT_LANG ?= EN
 SUPPORTED_LANGUAGES = EN FR DE ID IT ES CA GL EU RU PT_BR ZH_CN
+DOCKERFILE = Dockerfile
 
 # Check if Bot token has been provided
 ifndef BOT_TOKEN
@@ -22,10 +24,14 @@ ifneq ($(strip $(VALID_LANG)), true)
     $(error Invalid default language provided)
 endif
 
+.PHONY: build force test
+
 build:
-	docker build -t "${NAME_LOW}" --build-arg BOT_TOKEN="${BOT_TOKEN}" --build-arg BOT_LANG="${BOT_LANG_UPP}" .
+	docker build -f "${DOCKERFILE}" -t "${NAME_LOW}" --build-arg BOT_TOKEN="${BOT_TOKEN}" --build-arg BOT_LANG="${BOT_LANG_UPP}" .
 
 force:
-	docker build -t "${NAME_LOW}" --no-cache --build-arg BOT_TOKEN="${BOT_TOKEN}" --build-arg BOT_LANG="${BOT_LANG_UPP}" .
+	docker build -f "${DOCKERFILE}" -t "${NAME_LOW}" --no-cache --build-arg BOT_TOKEN="${BOT_TOKEN}" --build-arg BOT_LANG="${BOT_LANG_UPP}" .
 
-.PHONY: build force
+test:
+	$(MAKE) -e BOT_TOKEN=XXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+	docker run -it $(NAME_LOW):latest

--- a/sources/constants.py
+++ b/sources/constants.py
@@ -4,7 +4,7 @@
 Script:
     constants.py
 Description:
-    Constants values for join_captcha_bot.py.
+    Constants values for join_captcha_bot.py
 Author:
     Jose Rios Rubio
 Creation date:
@@ -15,14 +15,12 @@ Version:
     1.10.3
 '''
 
-####################################################################################################
-
+################################################################################
 ### Imported modules ###
 
 from os import path
 
-####################################################################################################
-
+################################################################################
 ### Constants ###
 
 # Actual constants.py full path directory name
@@ -89,7 +87,7 @@ CONST = {
     # Maximum number of users allowed in each chat ignore list
     "IGNORE_LIST_MAX": 100,
 
-    # Command don't allow in private chat text (just english due in private chats we 
+    # Command don't allow in private chat text (just english due in private chats we
     # don't have language configuration
     "CMD_NOT_ALLOW_PRIVATE": "Can't use this command in the current chat.",
 

--- a/sources/entrypoint.sh
+++ b/sources/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rm -f ./data/captchas/*
+
+exec python3 -u join_captcha_bot.py

--- a/sources/join_captcha_bot.py
+++ b/sources/join_captcha_bot.py
@@ -5,9 +5,9 @@
 Script:
     join_captcha_bot.py
 Description:
-    Telegram Bot that send a captcha for each new user who join a group, and ban them if they 
-    can not solve the captcha in a specified time. This is an approach to deny access to groups of 
-    non-humans "users".
+    Telegram Bot that send a captcha for each new user who join a group, and ban them if they
+    can not solve the captcha in a specified time. This is an approach to deny access to groups of
+    non-humans "users"
 Author:
     Jose Rios Rubio
 Creation date:
@@ -18,9 +18,9 @@ Version:
     1.10.3
 '''
 
-####################################################################################################
+################################################################################
+### Imported modules
 
-### Imported modules ###
 import re
 from sys import exit
 from signal import signal, SIGTERM, SIGINT
@@ -34,16 +34,16 @@ from collections import OrderedDict
 from random import randint
 from telegram import (Update, InputMediaPhoto, InlineKeyboardButton, InlineKeyboardMarkup,
     ChatPermissions)
-from telegram.ext import (CallbackContext, Updater, CommandHandler, MessageHandler, Filters, 
+from telegram.ext import (CallbackContext, Updater, CommandHandler, MessageHandler, Filters,
     CallbackQueryHandler, Defaults)
 
 from constants import CONST, TEXT
 from tsjson import TSjson
 from lib.multicolor_captcha_generator.img_captcha_gen import CaptchaGenerator
 
-####################################################################################################
+################################################################################
+### Globals
 
-### Globals ###
 updater = None
 files_config_list = []
 to_delete_in_time_messages_list = []
@@ -53,9 +53,8 @@ new_users_list = []
 # Create Captcha Generator object of specified size (2 -> 640x360)
 CaptchaGen = CaptchaGenerator(2)
 
-####################################################################################################
-
-### Termination Signals Handler For Program Process ###
+################################################################################
+### Termination Signals Handler For Program Process
 
 def signal_handler(signal,  frame):
     '''Termination signals (SIGINT, SIGTERM) handler for program process'''
@@ -73,13 +72,13 @@ def signal_handler(signal,  frame):
     exit(0)
 
 
-### Signals attachment ###
+### Signals attachment
+
 signal(SIGTERM, signal_handler) # SIGTERM (kill pid) to signal_handler
 signal(SIGINT, signal_handler)  # SIGINT (Ctrl+C) to signal_handler
 
-####################################################################################################
-
-### Auxiliar Functions ###
+################################################################################
+### Auxiliar Functions
 
 def printts(to_print="", timestamp=True):
     '''printts with timestamp.'''
@@ -195,9 +194,8 @@ def list_remove_element(the_list, the_element):
         return False
     return True
 
-####################################################################################################
-
-### JSON Chat Config File Functions ###
+################################################################################
+### JSON Chat Config File Functions
 
 def get_default_config_data():
     '''Get default config data structure'''
@@ -264,9 +262,8 @@ def get_chat_config_file(chat_id):
         files_config_list.append(file)
     return file["File"]
 
-####################################################################################################
-
-### Telegram Related Functions ###
+################################################################################
+### Telegram Related Functions
 
 def tlg_user_is_admin(bot, user_id, chat_id):
     '''Check if the specified user is an Administrator of a group given by IDs'''
@@ -434,13 +431,13 @@ def tlg_leave_chat(bot, chat_id):
     return left
 
 
-def tlg_restrict_user(bot, chat_id, user_id, send_msg=None, send_media=None, 
-        send_stickers_gifs=None, insert_links=None, send_polls=None, 
+def tlg_restrict_user(bot, chat_id, user_id, send_msg=None, send_media=None,
+        send_stickers_gifs=None, insert_links=None, send_polls=None,
         invite_members=None, pin_messages=None, change_group_info=None):
     '''Telegram Bot try to restrict user permissions in a group.'''
     result = False
     try:
-        permissions = ChatPermissions(send_msg, send_media, send_polls, send_stickers_gifs, 
+        permissions = ChatPermissions(send_msg, send_media, send_polls, send_stickers_gifs,
             insert_links, change_group_info, invite_members, pin_messages)
         result = bot.restrictChatMember(chat_id, user_id, permissions)
     except Exception as e:
@@ -464,9 +461,8 @@ def is_valid_user_id_or_alias(user_id_alias):
         return False
     return False
 
-####################################################################################################
-
-### General Functions ###
+################################################################################
+### General Functions
 
 def initialize_resources():
     '''Initialize resources by populating files list with chats found files'''
@@ -599,9 +595,8 @@ def is_user_inignored_list(chat_id, user):
             return True
     return False
 
-####################################################################################################
-
-### Received Telegram not-command messages handlers ###
+################################################################################
+### Received Telegram not-command messages handlers
 
 def msg_new_user(update: Update, context: CallbackContext):
     '''New member join the group event handler'''
@@ -634,7 +629,7 @@ def msg_new_user(update: Update, context: CallbackContext):
             join_user_name = join_user_name[0:35]
         # If the added user is myself (this Bot)
         if bot.id == join_user_id:
-            # Get the language of the Telegram client software the Admin that has added the Bot 
+            # Get the language of the Telegram client software the Admin that has added the Bot
             # has, to assume this is the chat language and configure Bot language of this chat
             admin_language = update.message.from_user.language_code[0:2].upper()
             if admin_language not in TEXT:
@@ -701,7 +696,7 @@ def msg_new_user(update: Update, context: CallbackContext):
             # Determine configured bot language in actual chat
             captcha_level = get_chat_config(chat_id, "Captcha_Difficulty_Level")
             captcha_chars_mode = get_chat_config(chat_id, "Captcha_Chars_Mode")
-            # Generate a pseudorandom captcha send it to telegram group and program message 
+            # Generate a pseudorandom captcha send it to telegram group and program message
             # selfdestruct
             captcha = create_image_captcha(str(join_user_id), captcha_level, captcha_chars_mode)
             captcha_timeout = get_chat_config(chat_id, "Captcha_Time")
@@ -913,8 +908,8 @@ def msg_nocmd(update: Update, context: CallbackContext):
             # Check for send just text message option and apply user restrictions
             restrict_non_text_msgs = get_chat_config(chat_id, "Restrict_Non_Text")
             if restrict_non_text_msgs:
-                tlg_restrict_user(bot, chat_id, user_id, send_msg=True, send_media=False, 
-                    send_stickers_gifs=False, insert_links=False, send_polls=False, 
+                tlg_restrict_user(bot, chat_id, user_id, send_msg=True, send_media=False,
+                    send_stickers_gifs=False, insert_links=False, send_polls=False,
                     invite_members=False, pin_messages=False, change_group_info=False)
         # The provided message doesn't has the valid captcha number
         else:
@@ -952,7 +947,7 @@ def msg_nocmd(update: Update, context: CallbackContext):
                             has_alias = True
                             #alias = word
                             break
-                    # Check if the detected alias is from a valid chat (commented due to getChat 
+                    # Check if the detected alias is from a valid chat (commented due to getChat
                     # request doesnt tell us if an alias is from an user, just group or channel)
                     #has_alias = False
                     #if has_alias:
@@ -1034,9 +1029,8 @@ def button_request_captcha(update: Update, context: CallbackContext):
     printts(" ")
     bot.answer_callback_query(query.id)
 
-####################################################################################################
-
-### Received Telegram command messages handlers ###
+################################################################################
+### Received Telegram command messages handlers
 
 def cmd_start(update: Update, context: CallbackContext):
     '''Command /start message handler'''
@@ -1616,9 +1610,8 @@ def cmd_whitelist(update: Update, context: CallbackContext):
             else:
                 tlg_send_selfdestruct_msg(bot, chat_id, "The User is not in Global Whitelist.")
 
-####################################################################################################
-
-### Main Loop Functions ###
+################################################################################
+### Main Loop Functions
 
 def handle_remove_and_kicks(bot):
     '''Handle remove of sent messages and not verify new users ban'''
@@ -1671,8 +1664,8 @@ def check_time_to_kick_not_verify_users(bot):
         new_user = new_users_list[i]
         captcha_timeout = get_chat_config(new_user["chat_id"], "Captcha_Time")
         if new_user["kicked_ban"]:
-            # Remove from new users list the remaining kicked users that have not solve the captcha 
-            # in 1 hour (user ban just happen if a user try to join the group and fail to solve the 
+            # Remove from new users list the remaining kicked users that have not solve the captcha
+            # in 1 hour (user ban just happen if a user try to join the group and fail to solve the
             # captcha 5 times in the past hour)
             if time() >= (new_user["join_time"] + captcha_timeout*60) + 3600:
                 # Remove user from new users list
@@ -1778,9 +1771,8 @@ def check_time_to_kick_not_verify_users(bot):
             printts(" ")
         i = i + 1
 
-####################################################################################################
-
-### Main Function ###
+################################################################################
+### Main Function
 
 def main():
     '''Main Function'''
@@ -1838,5 +1830,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-### End Of Code ###

--- a/sources/kill
+++ b/sources/kill
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 PID=`ps -aux | grep -e "[j]oin_captcha_bot.py" | awk 'FNR == 1 {print $2}'`
 
 if [ ! -z "$PID" ]; then

--- a/sources/run
+++ b/sources/run
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 PID=`ps -aux | grep -e "[j]oin_captcha_bot.py" | awk 'FNR == 1 {print $2}'`
 
 if [ -z "$PID" ]; then

--- a/sources/status
+++ b/sources/status
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 PID=`ps -aux | grep -e "[j]oin_captcha_bot.py" | awk 'FNR == 1 {print $2}'`
 
 if [ -z "$PID" ]; then

--- a/sources/tsjson.py
+++ b/sources/tsjson.py
@@ -54,7 +54,7 @@ class TSjson(object):
             read = None # Devolver None
         finally: # Para acabar, haya habido excepcion o no
             self.lock.release() # Abrimos (liberamos) el mutex
-        
+
         return read # Devolver el resultado de la lectura de la funcion
 
 
@@ -64,7 +64,7 @@ class TSjson(object):
         directory = os.path.dirname(self.file_name) # Obtener el nombre del directorio que contiene al archivo
         if not os.path.exists(directory): # Si el directorio (ruta) no existe
             os.makedirs(directory) # Creamos el directorio
-        
+
         try: # Intentar abrir el archivo
             self.lock.acquire() # Cerramos (adquirimos) el mutex
             with open(self.file_name, 'w', encoding="utf-8") as f: # Abrir el archivo en modo escritura (sobre-escribe)
@@ -78,7 +78,7 @@ class TSjson(object):
     def read_content(self):
         '''Funcion para leer el contenido de un archivo json (datos json)'''
         read = self.read() # Leer todo el archivo json
-        
+
         if read != {}: # Si la lectura no es vacia
             return read['Content'] # Devolvemos el contenido de la lectura (datos json)
         else: # Lectura vacia
@@ -91,23 +91,23 @@ class TSjson(object):
         directory = os.path.dirname(self.file_name) # Obtener el nombre del directorio que contiene al archivo
         if not os.path.exists(directory): # Si el directorio (ruta) no existe
             os.makedirs(directory) # Creamos el directorio
-        
+
         try: # Intentar abrir el archivo
             self.lock.acquire() # Cerramos (adquirimos) el mutex
-            
+
             if data: # Si el dato no esta vacio
                 if os.path.exists(self.file_name) and os.stat(self.file_name).st_size: # Si el archivo existe y no esta vacio
                     with open(self.file_name, "r", encoding="utf-8") as f: # Abrir el archivo en modo lectura
                         content = json.load(f, object_pairs_hook=OrderedDict) # Leer todo el archivo y devolver la lectura de los datos json usando un diccionario ordenado
 
                     content['Content'].append(data) # Añadir los nuevos datos al contenido del json
-                    
+
                     with open(self.file_name, 'w', encoding="utf-8") as f: # Abrir el archivo en modo escritura (sobre-escribe)
                         json.dump(content, fp=f, ensure_ascii=False, indent=4)
                 else: # El archivo no existe o esta vacio
                     with open(self.file_name, 'w', encoding="utf-8") as f: # Abrir el archivo en modo escritura (sobre-escribe)
                         f.write('\n{\n    "Content": []\n}\n') # Escribir la estructura de contenido basica
-                    
+
                     with open(self.file_name, "r", encoding="utf-8") as f: # Abrir el archivo en modo lectura
                         content = json.load(f) # Leer todo el archivo
 
@@ -188,7 +188,7 @@ class TSjson(object):
         [Nota: Cada dato json necesita al menos 1 elemento identificador unico (uide), si no es asi, la actualizacion se producira en el primer dato con dicho elemento uide que se encuentre]
         '''
         file_data = self.read() # Leer todo el archivo json
-        
+
         # Buscar la posicion del dato en el contenido json
         found = 0 # Posicion encontrada a 0
         i = 0 # Posicion inicial del dato a 0
@@ -197,7 +197,7 @@ class TSjson(object):
                 found = 1 # Marcar que se ha encontrado la posicion
                 break # Interrumpir y salir del bucle
             i = i + 1 # Incrementar la posicion del dato
-        
+
         if found: # Si se encontro en el archivo json datos con el UIDE buscado
             file_data['Content'][i] = data # Actualizamos los datos json que contiene ese UIDE
             self.write(file_data) # Escribimos el dato actualizado en el archivo json
@@ -211,7 +211,7 @@ class TSjson(object):
         [Nota: Cada dato json necesita al menos 1 elemento identificador unico (uide), si no es asi, la actualizacion se producira en el primer elemento que se encuentre]
         '''
         file_data = self.read() # Leer todo el archivo json
-        
+
         # Buscar la posicion del dato en el contenido json
         found = 0 # Posicion encontrada a 0
         i = 0 # Posicion inicial del dato a 0
@@ -220,7 +220,7 @@ class TSjson(object):
                 found = 1 # Marcar que se ha encontrado la posicion
                 break # Interrumpir y salir del bucle
             i = i + 1 # Incrementar la posicion del dato
-        
+
         if found: # Si se encontro en el archivo json datos con el UIDE buscado
             file_data['Content'][i] = data # Actualizamos los datos json que contiene ese UIDE
             self.write(file_data) # Escribimos el dato actualizado en el archivo json
@@ -239,7 +239,7 @@ class TSjson(object):
             print("    Error cuando se abria para escritura, el archivo {}".format(self.file_name)) # Escribir en consola el error
         finally: # Para acabar, haya habido excepcion o no
             self.lock.release() # Abrimos (liberamos) el mutex
-    
+
 
     def delete(self):
         '''Funcion para eliminar un archivo json'''

--- a/sources/tsjson.py
+++ b/sources/tsjson.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+
 '''
 Script:
     tsjson.py
 Description:
-    Thread-Safe json files read/write library.
+    Thread-Safe json files read/write library
 Author:
     Jose Rios Rubio
 Creation date:
@@ -15,17 +15,17 @@ Version:
     1.2.0
 '''
 
-####################################################################################################
+################################################################################
+### Modulos importados
 
-### Modulos importados ###
 import os
 import json
 from threading import Lock
 from collections import OrderedDict
 
-####################################################################################################
+################################################################################
+### Clase
 
-### Clase ###
 class TSjson(object):
     '''
     Thread-Safe json files read/write library


### PR DESCRIPTION
**Dockerfile refactor**

- Added buildkit syntax to allow build steps to be cached and speed up when rebuilding
- Use a smaller base image python:3-slim-buster rather than the full debian:buster
- Exported ARGs as ENV vars to share them between build steps
- Added quiet options for APT
- Drop privileges and run app as nobody:nogroup
- Run in /srv/app directory
- Renamed entrypoint script

**TODO**
- Check if we can build this FROM python:3-alpine to slim down the image even more

**Makefile refactor**
- Added SHELL to run everything in bash
- Added feature to change Dockerfile for test builds
- Added test target
- Add a debug target to build the container and hop on it

**Misc refactors**
- Added entrypoint script for docker container
- Added shebang for utility scripts
- Converted tsjson.py to UNIX format