### PR TITLE
Fix kill script not working because of wrong signal

### DIFF
--- a/sources/kill
+++ b/sources/kill
@@ -9,7 +9,7 @@ fi
 
 kill $PID
 echo "Killing script, please wait..."
-while $(kill -0 $PID 2>/dev/null); do
+while $(kill -9 $PID 2>/dev/null); do
     sleep 1
 done
 ./status


### PR DESCRIPTION
The kill command should send either -9 or -15 to stop the process, instead of -0
There is no signal 0 in unix.