### PR TITLE
fix docker image & sed command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 
 # TODO: Check if we can build this FROM python:3-alpine to slim down the image
 
-FROM python:3-slim-buster AS base
+FROM python:3.8.8-slim-buster AS base
 
 # Build ARGs
 ARG BOT_PROJECT="captcha-bot"
@@ -76,8 +76,8 @@ WORKDIR ${BOT_HOME_DIR}
 RUN git clone --recurse-submodules ${GITHUB_URL} ${APP_DIR} && \
     pip3 install --user --requirement ${APP_DIR}/requirements.txt && \
     cd ${APP_DIR}/sources && \
-    sed -i -e "s/${INVALID_TOKEN}/${BOT_TOKEN}/g" constants.py && \
-    sed -i -e "s/^\(\s\+\"INIT_LANG\"\)[^:]*:.*/\1 : \"${BOT_LANG}\",/g" constants.py && \
+    sed -i -e "s/${INVALID_TOKEN}/${BOT_TOKEN}/g" settings.py && \
+    sed -i -e "s/\"${BOT_LANG}\"/\"${BOT_LANG}\"/g" settings.py && \
     chown -cR ${BOT_USER}:${BOT_GROUP} ${BOT_HOME_DIR} && \
     rm -rf ${BOT_HOME_DIR}/.cache && \
     find ${APP_DIR} -iname '.git*' -print0 | xargs -0 -r -t rm -rf

--- a/docker/README.md
+++ b/docker/README.md
@@ -63,6 +63,12 @@ This will start the container in the background. Use `docker ps` to check if
 the container is up and running, and `docker logs captcha-bot` to
 investigate the logs.
 
+You can also run with other environment variable. For list of available environment variable, please check `sources/settings.py`. For example:
+
+```bash
+docker run -d --name captcha-bot --env CAPTCHABOT_OWNER="@owner" captcha-bot
+```
+
 ## Stopping the bot
 
 To stop the bot, use


### PR DESCRIPTION
1.  `python:3-slim-buster` image currently using python 3.9 that doesn't support by `Pillow 7.1.2`. https://pillow.readthedocs.io/en/stable/installation.html
2. Default configuration is in `settings.py`. Fix seeding directly to the `settings.py`
3. Add docs to enable the user to add an additional environment variable


Signed-off-by: zufardhiyaulhaq <zufardhiyaulhaq@gmail.com>