### PR TITLE
Allow to set up custom ban duration via CAPTCHABOT_BAN_DURATION option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/.vscode/
 **/__pycache__/
 **/data/
+**/.idea/
 
 **/*.pyc
 **/*.pkl

--- a/src/constants.py
+++ b/src/constants.py
@@ -220,6 +220,12 @@ CONST = {
         int(os_getenv("CAPTCHABOT_MAX_FAIL_BAN_POLL",
                       SETTINGS["CAPTCHABOT_MAX_FAIL_BAN_POLL"])),
 
+    # Duration of ban (in seconds, negative values mean indefinite ban).
+    # Useful if you want to ban someone temporarily.
+    "BAN_DURATION":
+        int(os_getenv("CAPTCHABOT_BAN_DURATION",
+                      SETTINGS["CAPTCHABOT_BAN_DURATION"])),
+
     # Last session restorable RAM data backup file path
     "F_SESSION": SCRIPT_PATH + "/session.pkl",
 

--- a/src/join_captcha_bot.py
+++ b/src/join_captcha_bot.py
@@ -32,6 +32,9 @@ from asyncio import sleep as asyncio_sleep
 # Collections Data Types Library
 from collections import OrderedDict
 
+# Date and Time Library
+from datetime import datetime, timedelta, timezone
+
 # JSON Library
 from json import dumps as json_dumps
 
@@ -873,7 +876,11 @@ async def captcha_fail_member_kick(bot, chat_id, user_id, user_name):
         logger.info("[%s] Captcha Fail - Ban - %s (%s)",
                     chat_id, user_name, user_id)
         # Try to ban the user and notify Admins
-        ban_result = await tlg_ban_user(bot, chat_id, user_id)
+        if CONST["BAN_DURATION"] >= 0:
+            ban_until_date = datetime.now(timezone.utc) + timedelta(seconds=CONST["BAN_DURATION"])
+        else:
+            ban_until_date = None
+        ban_result = await tlg_ban_user(bot, chat_id, user_id, until_date=ban_until_date)
         if ban_result["error"] == "":
             # Ban success
             banned = True

--- a/src/settings.py
+++ b/src/settings.py
@@ -168,5 +168,9 @@ SETTINGS = {
     # Maximum number of times a user fail to solve a Poll captcha.
     # If a user don't solve the captcha after this, it will be ban
     # instead kick
-    "CAPTCHABOT_MAX_FAIL_BAN_POLL": 3
+    "CAPTCHABOT_MAX_FAIL_BAN_POLL": 3,
+
+    # Duration of ban (in seconds, negative values mean indefinite ban).
+    # Useful if you want to ban someone temporarily.
+    "CAPTCHABOT_BAN_DURATION": -1,
 }


### PR DESCRIPTION
I'm not sure if this feature is needed by the community, but in our chat, we decided to give users temporary bans to prevent them from instantly rejoining (we use this bot as a soft power tool, just to let users know they've chosen the wrong chat).

I found that `tlgbotutils.tlg_ban_user` already has a parameter for ban duration, so I added a configuration option to specify it. By default, it's set to `-1`, which means an indefinite ban, so backward compatibility is maintained.

Important: I didn’t change the localization texts for the ban to avoid overcomplicating the logic, so the ban message still says that a chat admin needs to manually unban the user.