### PR TITLE
Fix /time <value> command to require unit specification instead of defaulting to minutes

### DIFF
--- a/src/join_captcha_bot.py
+++ b/src/join_captcha_bot.py
@@ -2370,13 +2370,28 @@ async def cmd_time(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 bot, chat_type, chat_id, TEXT[lang]["TIME_NOT_NUM"],
                 topic_id=tlg_get_msg_topic(update_msg))
         return
-    # Get time arguments
+    # Require user to provide unit
+    if len(args) < 2:
+        await tlg_send_msg_type_chat(
+               bot, chat_type, chat_id,
+               """⚠️ Please specify unit.
+        Usage:
+        Seconds:
+        /time <value> sec
+        or /time <value> secs
+        or /time <value> seconds
+        or /time <value> s
+        Minutes:
+        /time <value> min
+        or /time <value> mins
+        or /time <value> minutes
+        or /time <value> m""",
+               topic_id=tlg_get_msg_topic(update_msg))
+        return
+    # Get time value and unit
     new_time = int(args[0])
-    min_sec = "min"
-    if len(args) > 1:
-        min_sec = args[1].lower()
-    # Check if time format is not minutes or seconds
-    # Convert time value to seconds if min format
+    min_sec = args[1].lower()
+    # Validate and convert
     if min_sec in ["m", "min", "mins", "minutes"]:
         min_sec = "min"
         new_time_str = f"{new_time} min"

--- a/src/join_captcha_bot.py
+++ b/src/join_captcha_bot.py
@@ -2374,18 +2374,7 @@ async def cmd_time(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if len(args) < 2:
         await tlg_send_msg_type_chat(
                bot, chat_type, chat_id,
-               """⚠️ Please specify unit.
-        Usage:
-        Seconds:
-        /time <value> sec
-        or /time <value> secs
-        or /time <value> seconds
-        or /time <value> s
-        Minutes:
-        /time <value> min
-        or /time <value> mins
-        or /time <value> minutes
-        or /time <value> m""",
+               TEXT[lang]["TIME_UNIT_REQUIRED"],
                topic_id=tlg_get_msg_topic(update_msg))
         return
     # Get time value and unit

--- a/src/language/ar.json
+++ b/src/language/ar.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/be.json
+++ b/src/language/be.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/ca.json
+++ b/src/language/ca.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/de.json
+++ b/src/language/de.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/el.json
+++ b/src/language/el.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/en.json
+++ b/src/language/en.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/eo.json
+++ b/src/language/eo.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/es.json
+++ b/src/language/es.json
@@ -309,5 +309,7 @@
         "Configuración cambiada. Los Mensajes de Captcha se enviarán en un solo idioma.",
 
     "BILANG_MSG_YES":
-        "Configuración cambiada. Los Mensajes de Captcha se enviarán en dos idiomas."
+        "Configuración cambiada. Los Mensajes de Captcha se enviarán en dos idiomas.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/eu.json
+++ b/src/language/eu.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/fa.json
+++ b/src/language/fa.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/fi.json
+++ b/src/language/fi.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/fr.json
+++ b/src/language/fr.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/gl.json
+++ b/src/language/gl.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/he.json
+++ b/src/language/he.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/id.json
+++ b/src/language/id.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/it.json
+++ b/src/language/it.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/kn.json
+++ b/src/language/kn.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/ko.json
+++ b/src/language/ko.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/nl.json
+++ b/src/language/nl.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/pl.json
+++ b/src/language/pl.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/pt_br.json
+++ b/src/language/pt_br.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/ru.json
+++ b/src/language/ru.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/sk.json
+++ b/src/language/sk.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/sr.json
+++ b/src/language/sr.json
@@ -309,5 +309,7 @@
         "Konfiguracija je promenjena. Tekst Captcha poruka će biti prikazan na jednom jeziku.",
 
     "BILANG_MSG_YES":
-        "Konfiguracija je promenjena. Tekst Captcha poruka će biti prikazan na dva jezika."
+        "Konfiguracija je promenjena. Tekst Captcha poruka će biti prikazan na dva jezika.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/tr.json
+++ b/src/language/tr.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/uk.json
+++ b/src/language/uk.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/uz.json
+++ b/src/language/uz.json
@@ -309,5 +309,7 @@
         "Sozlama o‘zgartirildi. CAPTCHA xabar matnlari faqat bitta tilda ko‘rsatiladi.",
 
     "BILANG_MSG_YES":
-        "Sozlama o‘zgartirildi. CAPTCHA xabar matnlari ikkita til (inglizcha va tanlangan til) ko‘rsatiladi."
+        "Sozlama o‘zgartirildi. CAPTCHA xabar matnlari ikkita til (inglizcha va tanlangan til) ko‘rsatiladi.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }

--- a/src/language/zh_cn.json
+++ b/src/language/zh_cn.json
@@ -309,5 +309,7 @@
         "Configuration changed. Captcha messages text will be shown in a single language.",
 
     "BILANG_MSG_YES":
-        "Configuration changed. Captcha messages text will be shown in two languages."
+        "Configuration changed. Captcha messages text will be shown in two languages.",
+    "TIME_UNIT_REQUIRED":
+     "⚠️ Please specify unit.\nUsage:\nSeconds:\n/time <value> sec\nor /time <value> secs\nor /time <value> seconds\nor /time <value> s\nMinutes:\n/time <value> min\nor /time <value> mins\nor /time <value> minutes\nor /time <value> m"
 }


### PR DESCRIPTION
Previously, when a user typed /time <number> without specifying a unit, the bot defaulted to minutes, which could confuse users. 
If the user does not provide a unit, it will return a message like:
 Please specify unit:
Usage: 
Seconds: /time <value> sec or /time <value> secs or /time <value> seconds or /time <value> s 
Minutes: /time <value> min or /time <value> mins or /time <value> minutes or /time <value> m.
![WhatsApp Image 2025-12-05 at 10 25 52 AM](https://github.com/user-attachments/assets/154b25ff-1e1a-40f8-a1f7-810726bd2c43)